### PR TITLE
Updated example/config.yml

### DIFF
--- a/example/config.yml
+++ b/example/config.yml
@@ -35,6 +35,7 @@ passphrase:
 
 ## Define default options for all groups. ##
 default:
+  hourly: 1
   daily: 4
   weekly: 2
   monthly: 5


### PR DESCRIPTION
Leaving the "hourly" parameter unspecified in a group will lead to all backups being kept on every "clean" pass, regardless of their daily/weekly/monthly/yearly parameters. It took me a while to figure out that the problem was that the group I had created did not specify "hourly". If "hourly" is specified in defaults as "1", at least when not specifying it in individual groups it won't affect the cleanup of backups.